### PR TITLE
Use consistent title case for offer evaluation button

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -548,7 +548,7 @@ with tab4:
         miles_price = st.number_input("Miles", min_value=0, step=1000, key="purchase_miles_offer")
         bonus_miles = st.number_input("Bonus Miles (if any)", min_value=0, step=1000, key="purchase_miles_bonus_offer")
         
-    if st.button("Evaluate The offer"):
+    if st.button("Evaluate the Offer"):
         # Check if we have enough data to make a comparison
         if miles_price == 0:
             st.warning("Please enter miles.")


### PR DESCRIPTION
## Summary
- Align the miles purchase evaluation button text with title case for UI consistency.

## Testing
- `pytest -q` *(fails: TestTicketPurchase.test_miles_redemption_value, TestIntegration.test_helper_integration, TestStreamlitUI.test_award_accelerator_ui)*


------
https://chatgpt.com/codex/tasks/task_e_68900e43091c8323a81cf722c4cc3e53